### PR TITLE
added pg_collkey dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@ ids
 ===
 
 Intercontinental Dictionary Series
+
+Dependencies
+------------
+
+requires (pg_collkey)[git@github.com:ccutrer/pg_collkey.git]:
+
+```sh
+sudo apt install libicu-dev icu-devtools
+git clone git@github.com:ccutrer/pg_collkey.git
+cd pg_collkey
+make && sudo make install
+```

--- a/README.md
+++ b/README.md
@@ -6,11 +6,27 @@ Intercontinental Dictionary Series
 Dependencies
 ------------
 
-requires [pg_collkey](git@github.com:ccutrer/pg_collkey.git):
+requires [pg_collkey](https://www.public-software-group.org/pg_collkey).
 
 ```sh
-sudo apt install libicu-dev icu-devtools
-git clone git@github.com:ccutrer/pg_collkey.git
-cd pg_collkey
+sudo apt install libicu-dev icu-devtools postgresql-server-dev-all
+curl -O https://www.public-software-group.org/pub/projects/pg_collkey/v0.5/pg_collkey-v0.5.tar.gz
+tar -xzf pg_collkey-v0.5.tar.gz
+cd pg_collkey-c5.0
+```
+
+Before compiling adjust in `Makefile` the path variables ICU_CFLAGS,
+ICU_LDFLAGS, PG_INCLUDE_DIR, PG_PKG_LIB_DIR according to your OS and
+settings.  E.g. on Ubuntu change ICU_CFLAGS and ICU_LDFLAGS to the
+following:
+
+```make
+ICU_CFLAGS = `pkg-config --clfags icu-uc`
+ICU_LDFLAGS = `pkg-config --libs icu-uc`
+```
+
+Now compile and install:
+
+```sh
 make && sudo make install
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Intercontinental Dictionary Series
 Dependencies
 ------------
 
-requires (pg_collkey)[git@github.com:ccutrer/pg_collkey.git]:
+requires [pg_collkey](git@github.com:ccutrer/pg_collkey.git):
 
 ```sh
 sudo apt install libicu-dev icu-devtools


### PR DESCRIPTION
`sudo make install` returns an error (`icu-config: Command not found`), but it works anyways.  Don't know if one should investigate this before publishing

﻿- added note about pg_collkey dependency
- fixed link formatting
